### PR TITLE
Update greenlight to v3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ bbb_greenlight_image: bigbluebutton/greenlight:v2
 bbb_greenlight_etcdir: /etc/bigbluebutton/greenlight
 bbb_greenlight_libdir: /var/lib/greenlight
 bbb_greenlight_dbdir: "{{ bbb_greenlight_libdir }}/production"
+bbb_greenlight_storagedir: "{{ bbb_greenlight_libdir }}/storage"
 bbb_greenlight_logdir: /var/log/greenlight
 bbb_greenlight_redirect_root: false
 bbb_greenlight_db_adapter: postgresql
@@ -31,7 +32,10 @@ bbb_greenlight_db_name: greenlight_production
 bbb_greenlight_db_port: 5432
 bbb_greenlight_environment: {}
 bbb_greenlight_environment_defaults:
-  HELP_URL: "https://docs.bigbluebutton.org/greenlight/gl-overview.html"
+  HELP_URL: "https://docs.bigbluebutton.org/greenlight/v3/install"
+  REDIS_URL: "redis://redis:6379"
+  DATABASE_URL: "{{ bbb_greenlight_db_adapter }}://{{ bbb_greenlight_db_username }}:{{ bbb_greenlight_db_password }}@{{ bbb_greenlight_db_host }}:{{ bbb_greenlight_db_port }}/{{ bbb_greenlight_db_name }}"
+  SECRET_KEY_BASE: "{{ bbb_greenlight_rails_secret }}"
   ALLOW_GREENLIGHT_ACCOUNTS: "true"
   DEFAULT_REGISTRATION: "open"
   RELATIVE_URL_ROOT: "/b"
@@ -39,13 +43,6 @@ bbb_greenlight_environment_defaults:
   PAGINATION_NUMBER: "25"
   NUMBER_OF_ROWS: "25"
   MAINTENANCE_MODE: "false"
-  DB_ADAPTER: "{{ bbb_greenlight_db_adapter }}"
-  DB_HOST: "{{ bbb_greenlight_db_host }}"
-  DB_PORT: "{{ bbb_greenlight_db_port }}"
-  DB_NAME: "{{ bbb_greenlight_db_name }}"
-  DB_USERNAME: "{{ bbb_greenlight_db_username }}"
-  DB_PASSWORD: "{{ bbb_greenlight_db_password }}"
   ENABLE_SSL: "{{ bbb_configure_ssl | bool | string | lower }}"
-  SECRET_KEY_BASE: "{{ bbb_greenlight_rails_secret }}"
   BIGBLUEBUTTON_ENDPOINT: "{{ bbb_greenlight_extracted_endpoint }}"
   BIGBLUEBUTTON_SECRET: "{{ bbb_greenlight_extracted_secret }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: Restart NGINX
+  ansible.builtin.service:
+    name: nginx
+    state: restarted
+
+- name: Restart greenlight
+  ansible.builtin.systemd:
+    name: greenlight
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,12 +4,10 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
 
   platforms:
   - name: Ubuntu
-    versions:
-     - xenial
 
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is
@@ -21,10 +19,21 @@ galaxy_info:
     # alphanumeric characters. Maximum 20 tags per role.
 
 dependencies:
-  - role: thefinn93.letsencrypt
+  - role: geerlingguy.certbot
     vars:
-      letsencrypt_webroot_path: "{{ bbb_ssl_webroot_path }}"
-      letsencrypt_email: "{{ bbb_ssl_email }}"
-      letsencrypt_cert_domains: "{{ bbb_server_names }}"
-      letsencrypt_renewal_command_args: "{{ bbb_ssl_renewal_command_args }}"
+      certbot_install_method: package
+      certbot_create_if_missing: true
+      certbot_auto_renew: true
+      certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+      certbot_auto_renew_hour: "1"
+      certbot_auto_renew_minute: "44"
+      certbot_auto_renew_options: "--quiet"
+      certbot_admin_email: "{{ bbb_ssl_email }}"
+      certbot_certs:
+        - email: "{{ bbb_ssl_email }}"
+          webroot: "{{ bbb_ssl_webroot_path }}"
+          domains: "{{ bbb_server_names }}"
     when: bbb_configure_ssl == True
+  - role: geerlingguy.docker
+    vars:
+      docker_install_compose: true

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -1,13 +1,14 @@
+---
 # We restrict access permissions on libdir because it usually hosts the
 # database directory that is usually controlled by a DB container, and cannot
 # be sufficiently protected on the host itself (see below)
 - name: Create protected greenlight libdir
-  file:
+  ansible.builtin.file:
     path: "{{ bbb_greenlight_libdir }}"
     state: directory
     owner: root
     group: root
-    mode: 0700
+    mode: "0700"
   tags:
     - greenlight-config
 
@@ -23,173 +24,168 @@
 # container. As such, here we just ensure the dbdir is actually present,
 # but leave the eventual modes and ownership up to the container.
 - name: Create greenlight database directory
-  file:
+  ansible.builtin.file:
     path: "{{ bbb_greenlight_dbdir }}"
     state: directory
+    mode: "0755"
   tags:
     - greenlight-config
 
 - name: Create additional greenlight directories
-  file:
-    path: "{{ item }}"
+  ansible.builtin.file:
+    path: "{{ __bbb_greenlight_directories }}"
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
+  loop_control:
+    loop_var: __bbb_greenlight_directories
   loop:
     - "{{ bbb_greenlight_etcdir }}"
     - "{{ bbb_greenlight_logdir }}"
+    - "{{ bbb_greenlight_storagedir }}"
   tags:
     - greenlight-config
 
 - name: Create greenlight logrotate configuration
-  template:
+  ansible.builtin.template:
     src: templates/greenlight.logrotate.j2
     dest: /etc/logrotate.d/greenlight
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
   tags:
     - greenlight-config
 
 - name: Examine BBB configuration
-  command: /usr/bin/bbb-conf --secret
+  ansible.builtin.command: /usr/bin/bbb-conf --secret
   changed_when: false
   register: bbb_conf_secret
   tags:
     - greenlight-config
 
 - name: Extract BBB endpoint and secret
-  set_fact:
+  ansible.builtin.set_fact:
     bbb_greenlight_extracted_endpoint: "{{ bbb_conf_secret.stdout | regex_search('URL: (.*)', '\\1') | first }}"
     bbb_greenlight_extracted_secret: "{{ bbb_conf_secret.stdout | regex_search('Secret: (.*)', '\\1') | first }}"
   tags:
     - greenlight-config
 
-- name: Check if greenlight secret file exists
-  stat:
-    path: "{{ bbb_greenlight_etcdir }}/.rails.secret"
-  register: bbb_greenlight_rails_secret_file
-  tags:
-    - greenlight-config
+- name: Setup greenlight secret
+  block:
+    - name: Check if greenlight secret file exists
+      ansible.builtin.stat:
+        path: "{{ bbb_greenlight_etcdir }}/.rails.secret"
+      register: bbb_greenlight_rails_secret_file
+      failed_when: not bbb_greenlight_rails_secret_file.stat.exists
+      tags:
+        - greenlight-config
 
-- name: Create new greenlight secret
-  command: docker run --rm {{ bbb_greenlight_image }} bundle exec rake secret
-  register: bbb_greenlight_rails_secret
-  when: not bbb_greenlight_rails_secret_file.stat.exists
-  tags:
-    - greenlight-config
+  rescue:
+    - name: Create new greenlight secret
+      ansible.builtin.command: docker run --rm --entrypoint /bin/sh {{ bbb_greenlight_image }} -c "bundle exec rails secret"
+      register: bbb_greenlight_rails_secret
+      tags:
+        - greenlight-config
 
-- name: Persist new secret to file
-  copy:
-    content: "{{ bbb_greenlight_rails_secret.stdout }}"
-    dest: "{{ bbb_greenlight_etcdir }}/.rails.secret"
-    mode: 0600
-    owner: root
-    group: root
-  when: not bbb_greenlight_rails_secret_file.stat.exists
-  tags:
-    - greenlight-config
+    - name: Persist new secret to file
+      ansible.builtin.copy:
+        content: "{{ bbb_greenlight_rails_secret.stdout }}"
+        dest: "{{ bbb_greenlight_etcdir }}/.rails.secret"
+        mode: "0600"
+        owner: root
+        group: root
+      tags:
+        - greenlight-config
 
-- name: Read greenlight secret from file
-  command: cat "{{ bbb_greenlight_etcdir }}/.rails.secret"
-  changed_when: false
-  register: bbb_greenlight_rails_secret_content
-  tags:
-    - greenlight-config
+  always:
+    - name: Read greenlight secret from file
+      ansible.builtin.command: cat "{{ bbb_greenlight_etcdir }}/.rails.secret"
+      changed_when: false
+      register: bbb_greenlight_rails_secret_content
+      tags:
+        - greenlight-config
 
-- name: Transfer greenlight secret into proper variable
-  set_fact:
-    bbb_greenlight_rails_secret: "{{ bbb_greenlight_rails_secret_content.stdout }}"
-  tags:
-    - greenlight-config
+    - name: Transfer greenlight secret into proper variable
+      ansible.builtin.set_fact:
+        bbb_greenlight_rails_secret: "{{ bbb_greenlight_rails_secret_content.stdout }}"
+      tags:
+        - greenlight-config
 
-- name: Check if greenlight database secret file exists
-  stat:
-    path: "{{ bbb_greenlight_etcdir }}/.db.secret"
-  register: bbb_greenlight_db_secret_file
-  tags:
-    - greenlight-config
+- name: Setup database secret for greenlight
+  block:
+    - name: Check if greenlight database secret file exists
+      ansible.builtin.stat:
+        path: "{{ bbb_greenlight_etcdir }}/.db.secret"
+      register: bbb_greenlight_db_secret_file
+      failed_when: not bbb_greenlight_db_secret_file.stat.exists
+      tags:
+        - greenlight-config
+  rescue:
+    - name: Persist new database secret to file
+      ansible.builtin.copy:
+        content: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
+        dest: "{{ bbb_greenlight_etcdir }}/.db.secret"
+        mode: "0600"
+        owner: root
+        group: root
+      tags:
+        - greenlight-config
 
-- name: Create greenlight database password
-  set_fact:
-    bbb_greenlight_db_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
-  when: not bbb_greenlight_db_secret_file.stat.exists
-  tags:
-    - greenlight-config
+  always:
+    - name: Read greenlight database secret from file
+      ansible.builtin.command: cat "{{ bbb_greenlight_etcdir }}/.db.secret"
+      changed_when: false
+      register: bbb_greenlight_db_secret_content
+      tags:
+        - greenlight-config
 
-- name: Persist new database secret to file
-  copy:
-    content: "{{ bbb_greenlight_db_password }}"
-    dest: "{{ bbb_greenlight_etcdir }}/.db.secret"
-    mode: 0600
-    owner: root
-    group: root
-  when: not bbb_greenlight_db_secret_file.stat.exists
-  tags:
-    - greenlight-config
-
-- name: Read greenlight database secret from file
-  command: cat "{{ bbb_greenlight_etcdir }}/.db.secret"
-  changed_when: false
-  register: bbb_greenlight_db_secret_content
-  when: bbb_greenlight_db_secret_file.stat.exists
-  tags:
-    - greenlight-config
-
-- name: Transfer greenlight database secret into proper variable
-  set_fact:
-    bbb_greenlight_db_password: "{{ bbb_greenlight_db_secret_content.stdout }}"
-  when: bbb_greenlight_db_secret_file.stat.exists
-  tags:
-    - greenlight-config
+    - name: Transfer greenlight database secret into proper variable
+      ansible.builtin.set_fact:
+        bbb_greenlight_db_password: "{{ bbb_greenlight_db_secret_content.stdout }}"
+      tags:
+        - greenlight-config
 
 - name: Create greenlight docker-compose config
-  template:
+  ansible.builtin.template:
     src: templates/greenlight-docker-compose.yml.j2
     dest: "{{ bbb_greenlight_etcdir }}/docker-compose.yml"
     owner: root
     group: root
-    mode: 0600
+    mode: "0600"
     validate: /usr/local/bin/docker-compose -f %s config -q
   register: greenlight_config
+  notify:
+    - Restart greenlight
   tags:
     - greenlight-config
 
 - name: Create greenlight NGINX config stub
-  template:
+  ansible.builtin.template:
     src: templates/greenlight.nginx.j2
     dest: "/etc/bigbluebutton/nginx/greenlight.nginx"
     owner: root
     group: root
-    mode: 0644
-  register: nginx_config
-  tags:
-    - greenlight-config
-
-- name: Restart NGINX to activate greenlight changes
-  systemd:
-    name: nginx
-    state: restarted
-  when:
-    nginx_config.changed
+    mode: "0644"
+  notify:
+    - Restart NGINX
   tags:
     - greenlight-config
 
 - name: Create greenlight systemd unit file
-  template:
+  ansible.builtin.template:
     src: templates/greenlight.service.j2
     dest: /etc/systemd/system/greenlight.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   tags:
     - greenlight-service
 
 - name: Enable and start greenlight systemd service
-  systemd:
+  ansible.builtin.systemd:
     name: greenlight
     enabled: true
-    state: "{{ 'restarted' if greenlight_config.changed else 'started' }}"
+    state: started
   tags:
     - greenlight-service

--- a/templates/greenlight-docker-compose.yml.j2
+++ b/templates/greenlight-docker-compose.yml.j2
@@ -1,13 +1,14 @@
+# This file is inspired by https://github.com/bigbluebutton/greenlight/blob/master/docker-compose.yml
 version: '3'
 
 services:
   app:
     entrypoint: [bin/start]
     image: {{ bbb_greenlight_image }}
-    container_name: greenlight-v2
+    container_name: greenlight-v3
     restart: unless-stopped
     ports:
-      - 127.0.0.1:5000:80
+      - 127.0.0.1:5000:3000
     environment:
 {% set bbb_greenlight_environment_combined = bbb_greenlight_environment_defaults | combine(bbb_greenlight_environment) -%}
 {% for envvar in bbb_greenlight_environment_combined %}
@@ -18,11 +19,24 @@ services:
 {% if bbb_greenlight_db_adapter == 'sqlite3' %}
       - {{ bbb_greenlight_dbdir }}:/usr/src/app/db/production
 {% endif %}
+    logging:
+      driver: journald
 {% if bbb_greenlight_db_adapter == 'postgresql' and bbb_greenlight_db_host == 'db' %}
     links:
       - db
+      - redis
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: redis:6.2-alpine3.17
+    restart: unless-stopped
+    volumes:
+      - ./data/redis/database_data:/data
+
   db:
-    image: postgres:9.5
+    image: postgres:14.6-alpine3.17
     restart: unless-stopped
     ports:
       - 127.0.0.1:5432:{{ bbb_greenlight_db_port }}


### PR DESCRIPTION
By trying to install there come up some issues with the used dependencies and tasks for v2 greenlight. This pull request will fix the issues by deprecated naming conventions and old dependencies.

The role: thefinn93.letsencrypt is not updatet scince 3 Years now, switch to geerlingguy.certbot. Also add the geerlingguy.docker role to install docker-compose, this role is used by the active ansible-role-bigbluebutton project.